### PR TITLE
Common naming strategy for subtypes in JSON schemas

### DIFF
--- a/schema/src/main/java/org/creek/api/base/schema/naming/SubTypeNaming.java
+++ b/schema/src/main/java/org/creek/api/base/schema/naming/SubTypeNaming.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creek.api.base.schema.naming;
+
+/** Util class providing a default strategy for naming subtypes in JSON/YAML schemas. */
+public final class SubTypeNaming {
+
+    private SubTypeNaming() {}
+
+    /**
+     * Get the type name of a subtype of a polymorphic type.
+     *
+     * <p>Given a subtype {@code FooBar} of a base type {@code Bar}, this method will return {@code
+     * bar}.
+     *
+     * <p>Given a subtype {@code AnotherFooBar} of a base type {@code Bar}, this method will return
+     * {@code another_bar}.
+     *
+     * <p>When the subtype does not end with base type name this method returns the subtype name in
+     * lowercase.
+     *
+     * @param subType the subtype of the {@code baseType}
+     * @param baseType the base type
+     * @return the subtype name
+     */
+    public static <T> String subTypeName(
+            final Class<? extends T> subType, final Class<T> baseType) {
+        if (subType.isAnonymousClass() || subType.isSynthetic()) {
+            throw new IllegalArgumentException(
+                    "Anonymous/synthetic types are not supported: " + subType);
+        }
+
+        final String base = baseType.getSimpleName();
+        final String sub = subType.getSimpleName();
+        final String prefix =
+                sub.endsWith(base) ? sub.substring(0, sub.length() - base.length()) : sub;
+        final String name = prefix.replaceAll("([A-Z])", "_$1").toLowerCase();
+        return name.startsWith("_") ? name.substring(1) : name;
+    }
+}

--- a/schema/src/test/java/org/creek/api/base/schema/naming/SubTypeNamingTest.java
+++ b/schema/src/test/java/org/creek/api/base/schema/naming/SubTypeNamingTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creek.api.base.schema.naming;
+
+import static org.creek.api.base.schema.naming.SubTypeNaming.subTypeName;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class SubTypeNamingTest {
+
+    @Test
+    void shouldReturnPrefixIfSubTypeNamedEndsInBaseType() {
+        assertThat(subTypeName(SomeThing.class, Thing.class), is("some"));
+        assertThat(subTypeName(SomeOtherThing.class, Thing.class), is("some_other"));
+    }
+
+    @Test
+    void shouldReturnFullNameIfSubTypeNamedDoesNotEndInBaseType() {
+        assertThat(
+                subTypeName(TotallyDifferentName.class, Thing.class), is("totally_different_name"));
+        assertThat(subTypeName(SomeThingDifferent.class, Thing.class), is("some_thing_different"));
+    }
+
+    @Test
+    void shouldDoSomethingSensibleWithWierdNames() {
+        assertThat(
+                subTypeName(_$Weird_Class_$NAme_.class, Thing.class),
+                is("$_weird__class_$_n_ame_"));
+    }
+
+    @Test
+    void shouldThrowOnAnonymousTypes() {
+        // Given:
+        final Thing anonymousType = new Thing() {};
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> subTypeName(anonymousType.getClass(), Thing.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is("Anonymous/synthetic types are not supported: " + anonymousType.getClass()));
+    }
+
+    @Test
+    void shouldThrowOnSyntheticTypes() {
+        // Given:
+        final BaseFunctional lambda = () -> "name";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> subTypeName(lambda.getClass(), BaseFunctional.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is("Anonymous/synthetic types are not supported: " + lambda.getClass()));
+    }
+
+    private interface BaseFunctional {
+        @SuppressWarnings("unused")
+        String name();
+    }
+
+    private interface Thing {}
+
+    private interface SomeThing extends Thing {}
+
+    private interface SomeOtherThing extends Thing {}
+
+    private interface TotallyDifferentName extends Thing {}
+
+    private interface SomeThingDifferent extends Thing {}
+
+    @SuppressWarnings("checkstyle:TypeName")
+    private interface _$Weird_Class_$NAme_ extends Thing {}
+}


### PR DESCRIPTION
### Description
A common strategy is needed to ensure the type names used by the schema-generator lines up with what the system tests expects, etc.

