### PR TITLE
Enhance @GeneratesSchema type discovery

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("com.diffplug.spotless") version "6.5.1"                 // https://mvnrepository.com/artifact/com.diffplug.spotless/spotless-plugin-gradle
     id("pl.allegro.tech.build.axion-release") version "1.13.6"  // https://mvnrepository.com/artifact/pl.allegro.tech.build.axion-release/pl.allegro.tech.build.axion-release.gradle.plugin?repo=gradle-plugins
     id("com.github.kt3k.coveralls") version "2.12.0"            // https://plugins.gradle.org/plugin/com.github.kt3k.coveralls
-    id("org.javamodularity.moduleplugin") version "1.8.10"      // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
+    id("org.javamodularity.moduleplugin") version "1.8.10" apply false     // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
 }
 
 project.version = scmVersion.version
@@ -14,7 +14,6 @@ project.version = scmVersion.version
 allprojects {
     apply(plugin = "idea")
     apply(plugin = "java")
-    apply(plugin = "jacoco")
     apply(plugin = "checkstyle")
     apply(plugin = "com.diffplug.spotless")
     apply(plugin = "com.github.spotbugs")
@@ -45,6 +44,13 @@ allprojects {
 subprojects {
     apply(plugin = "maven-publish")
     apply(plugin = "org.javamodularity.moduleplugin")
+
+    configure(subprojects
+            // Exclude test modules from code coverage
+            - project(":test-module")
+    ) {
+        apply(plugin = "jacoco")
+    }
 
     project.version = project.parent?.version!!
 
@@ -130,7 +136,7 @@ subprojects {
         }
     }
 
-    tasks.jacocoTestReport {
+    tasks.withType<JacocoReport>().configureEach{
         dependsOn(tasks.test)
     }
 
@@ -146,24 +152,26 @@ subprojects {
         dependsOn("checkstyleMain", "checkstyleTest", "spotbugsMain", "spotbugsTest")
     }
 
-    publishing {
-        repositories {
-            maven {
-                name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/creek-service/${rootProject.name}")
-                credentials {
-                    username = System.getenv("GITHUB_ACTOR")
-                    password = System.getenv("GITHUB_TOKEN")
+    if (!project.name.startsWith("test-")) {
+        publishing {
+            repositories {
+                maven {
+                    name = "GitHubPackages"
+                    url = uri("https://maven.pkg.github.com/creek-service/${rootProject.name}")
+                    credentials {
+                        username = System.getenv("GITHUB_ACTOR")
+                        password = System.getenv("GITHUB_TOKEN")
+                    }
                 }
             }
-        }
-        publications {
-            create<MavenPublication>("maven") {
-                from(components["java"])
-                artifactId = "${rootProject.name}-${project.name}"
+            publications {
+                create<MavenPublication>("maven") {
+                    from(components["java"])
+                    artifactId = "${rootProject.name}-${project.name}"
 
-                pom {
-                    url.set("https://github.com/creek-service/${rootProject.name}.git")
+                    pom {
+                        url.set("https://github.com/creek-service/${rootProject.name}.git")
+                    }
                 }
             }
         }

--- a/schema/build.gradle.kts
+++ b/schema/build.gradle.kts
@@ -7,4 +7,6 @@ val classGraphVersion : String by extra
 dependencies {
     implementation(project(":annotation"))
     implementation("io.github.classgraph:classgraph:$classGraphVersion")
+
+    testImplementation(project(":test-module"))
 }

--- a/schema/src/main/java/org/creekservice/api/base/schema/GeneratesSchemas.java
+++ b/schema/src/main/java/org/creekservice/api/base/schema/GeneratesSchemas.java
@@ -16,11 +16,17 @@
 
 package org.creekservice.api.base.schema;
 
+import static java.util.Objects.requireNonNull;
 
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ModuleRef;
 import io.github.classgraph.ScanResult;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.creekservice.api.base.annotation.schema.GeneratesSchema;
 
@@ -32,23 +38,113 @@ public final class GeneratesSchemas {
 
     private GeneratesSchemas() {}
 
-    /**
-     * Find types annotated with {@link GeneratesSchema} on the class or module paths.
-     *
-     * @param packageName the name of the package to limit the search to. Sub packages are included.
-     * @return the list of all types annotated with {@link GeneratesSchema}.
-     */
-    public static Set<Class<?>> findAnnotatedTypes(final String packageName) {
-        try (ScanResult sr =
-                new ClassGraph()
-                        .enableClassInfo()
-                        .enableAnnotationInfo()
-                        .acceptPackages(packageName)
-                        .scan()) {
+    public static Scanner scanner() {
+        return new Scanner();
+    }
 
-            return sr.getClassesWithAnnotation(GeneratesSchema.class.getName()).stream()
-                    .map(ClassInfo::loadClass)
-                    .collect(Collectors.toUnmodifiableSet());
+    public static final class Scanner {
+
+        private final Set<String> allowedPackages = new HashSet<>();
+        private final Set<String> allowedModules = new HashSet<>();
+
+        private Scanner() {}
+
+        /**
+         * Add allowed packages.
+         *
+         * <p>By default, types from any package are returned. Specifying one or more allowed
+         * packages restricts the returned types to only those under the allowed packages.
+         *
+         * @param allowedPackages allowed packages to add. Package names may include the glob
+         *     wildcard {@code *} character.
+         * @return self
+         */
+        public Scanner withAllowedPackages(final Collection<String> allowedPackages) {
+            this.allowedPackages.addAll(allowedPackages);
+            return this;
+        }
+
+        /**
+         * Add allowed packages.
+         *
+         * <p>By default, types from any package are returned. Specifying one or more allowed
+         * packages restricts the returned types to only those under the allowed packages.
+         *
+         * @param allowedPackages allowed packages to add. Package names may include the glob
+         *     wildcard {@code *} character.
+         * @return self
+         */
+        public Scanner withAllowedPackages(final String... allowedPackages) {
+            return withAllowedPackages(List.of(allowedPackages));
+        }
+
+        /**
+         * Add allowed modules.
+         *
+         * <p>By default, types from any module are returned. Specifying one or more allowed modules
+         * restricts the returned types to only those types that belong to an allowed module.
+         *
+         * @param allowedModules allowed module names to add.
+         * @return self
+         */
+        public Scanner withAllowedModules(final Collection<String> allowedModules) {
+            this.allowedModules.addAll(allowedModules);
+            return this;
+        }
+
+        /**
+         * Add allowed modules.
+         *
+         * <p>By default, types from any module are returned. Specifying one or more allowed modules
+         * restricts the returned types to only those types that belong to an allowed module.
+         *
+         * @param allowedModules allowed module names to add.
+         * @return self
+         */
+        public Scanner withAllowedModules(final String... allowedModules) {
+            return withAllowedModules(List.of(allowedModules));
+        }
+
+        /**
+         * Find types annotated with {@link GeneratesSchema} on the class or module paths.
+         *
+         * @return the list of all types annotated with {@link GeneratesSchema}.
+         */
+        public Set<Class<?>> scan() {
+            final ModuleFilter moduleFilter = new ModuleFilter(allowedModules);
+
+            try (ScanResult sr =
+                    new ClassGraph()
+                            .enableClassInfo()
+                            .enableAnnotationInfo()
+                            .acceptPackages(allowedPackages.toArray(String[]::new))
+                            .scan()) {
+
+                return sr.getClassesWithAnnotation(GeneratesSchema.class.getName()).stream()
+                        .filter(moduleFilter)
+                        .map(ClassInfo::loadClass)
+                        .collect(Collectors.toUnmodifiableSet());
+            }
+        }
+    }
+
+    private static final class ModuleFilter implements Predicate<ClassInfo> {
+        private final Set<String> allowedModules;
+
+        ModuleFilter(final Collection<String> allowedModules) {
+            this.allowedModules = Set.copyOf(requireNonNull(allowedModules, "allowedModules"));
+        }
+
+        @Override
+        public boolean test(final ClassInfo classInfo) {
+            if (allowedModules.isEmpty()) {
+                return true;
+            }
+
+            final ModuleRef moduleRef = classInfo.getModuleRef();
+            return moduleRef != null
+                    && moduleRef.getName() != null
+                    && allowedModules.contains(moduleRef.getName());
         }
     }
 }

--- a/schema/src/test/java/module-info.test
+++ b/schema/src/test/java/module-info.test
@@ -1,8 +1,8 @@
 --add-modules
-  org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity
+  org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,creek.base.test.module
 
 --add-reads
-  creek.base.schema=org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity
+  creek.base.schema=org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,creek.base.test.module
 
 --add-opens
   org.junitpioneer/org.junitpioneer.jupiter=org.junit.platform.commons

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "creek-base"
 
 include(
     "annotation",
-    "type",
-    "schema"
+    "schema",
+    "test-module",
+    "type"
 )

--- a/test-module/README.md
+++ b/test-module/README.md
@@ -1,0 +1,3 @@
+# Test module
+
+A Java module containing types and utilities used privately by this repo for testing.

--- a/test-module/build.gradle.kts
+++ b/test-module/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    implementation(project(":annotation"))
+}

--- a/test-module/src/main/java/module-info.java
+++ b/test-module/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module creek.base.test.module {
+    requires creek.base.annotation;
+
+    exports org.creekservice.api.base.test.module;
+}

--- a/test-module/src/main/java/org/creekservice/api/base/test/module/ApiModel.java
+++ b/test-module/src/main/java/org/creekservice/api/base/test/module/ApiModel.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.base.test.module;
+
+
+import org.creekservice.api.base.annotation.schema.GeneratesSchema;
+
+@GeneratesSchema
+public final class ApiModel {}

--- a/test-module/src/main/java/org/creekservice/internal/base/test/module/InternalModel.java
+++ b/test-module/src/main/java/org/creekservice/internal/base/test/module/InternalModel.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.base.test.module;
+
+
+import org.creekservice.api.base.annotation.schema.GeneratesSchema;
+
+@SuppressWarnings("unused") // Accessed by class-graph
+@GeneratesSchema
+public final class InternalModel {}


### PR DESCRIPTION
Allow multiple package names to be passed to filter based on which package a type is under.
Allow multiple module names to be passed to filter based on which module a type belongs to.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended