### PR TITLE
Fail release on snapshot builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,12 +62,4 @@ subprojects {
     }
 }
 
-scmVersion {
-    checks {
-        // Required until https://github.com/allegro/axion-release-plugin/issues/549 fixed
-        // As there is a circular test-only dependency between creek-base and creek-test:
-        snapshotDependencies.set(false)
-    }
-}
-
 defaultTasks("format", "static", "check")


### PR DESCRIPTION
Now that creek-test is Creek-dependency free (https://github.com/creek-service/creek-test/pull/101), this repo can now fail to release on snapshot dependencies

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure correct labels applied
- [ ] Ensure any appropriate documentation has been added or amended