### PR TITLE
Fix concurrent mod in tests.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze
+    if: ${{ github.run_number != 1 }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/type/src/test/java/org/creekservice/api/base/type/config/SystemEnvTest.java
+++ b/type/src/test/java/org/creekservice/api/base/type/config/SystemEnvTest.java
@@ -24,12 +24,17 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
+@Isolated // This test uses @SetEnvironmentVariable, which modifies global env
+@Execution(SAME_THREAD) // ...this isn't thread-safe. So isolate from other tests.
 class SystemEnvTest {
 
     @SetEnvironmentVariable(key = "a-key", value = "-109")


### PR DESCRIPTION
Affected tests were using the @SetEnvironmentVariable. Under the hoods this is modifying global state, i.e. the map of env vars, and the map isn't thread-safe.

Fix is to isolate the affected tests: not running them concurrently with other tests.
