### PR TITLE
Schedule fortnightly build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,5 +79,3 @@ jobs:
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           generate_release_notes: true
-
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,5 @@ jobs:
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           generate_release_notes: true
-          
-          
-todo: use Gradle build plugin wiht dependency submission.
+
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,15 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
-    tags: [ "v*.*.*" ]
+    branches: 
+      - main
+    tags:
+      - "v*.*.*"
   pull_request:
-    branches: [ main ]
+    branches: 
+      - main
+  schedule:
+    - cron: "39 5 1,15 * *"
   workflow_dispatch:
     inputs:
       publish_artifacts:
@@ -74,3 +79,7 @@ jobs:
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           generate_release_notes: true
+          
+          
+todo: use Gradle build plugin wiht dependency submission.
+


### PR DESCRIPTION
Auto-merging dependabot PRs doesn't trigger a `main` build, meaning snapshots are not updated.  The known workaround for this is to use a PAT when doing the merge, but PATs introduce security concerns.

As an alternative to using PATs... schedule a fortnightly build of `main` to ensure snapshots, with updated dependencies, are building built.


