### PR TITLE
Pull dependency reporting into its own workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,10 @@ name: Build
 
 on:
   push:
-    branches:
-      - main
-    tags:
-      - "v*.*.*"
+    branches: [ main ]
+    tags: [ "v*.*.*" ]
   pull_request:
-    branches:
-      - main
+    branches: [ main ]
   schedule:
     - cron: "39 5 1,15 * *"
   workflow_dispatch:
@@ -44,13 +41,10 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         with:
-          dependency-graph: generate
           gradle-home-cache-cleanup: true
       - name: Build
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: runtimeClasspath
-          DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "^:(?!(buildSrc|test-)).*"
         run: ./gradlew build coveralls
       - name: Publish
         if: github.event_name == 'push' || github.event.inputs.publish_artifacts == 'true'
@@ -60,7 +54,6 @@ jobs:
           ORG_GRADLE_PROJECT_SONA_USERNAME: ${{ secrets.SONA_USERNAME }}
           ORG_GRADLE_PROJECT_SONA_PASSWORD: ${{ secrets.SONA_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "" # i.e. none
         run: |
           ./gradlew cV
           ./gradlew publish closeAndReleaseStagingRepository
@@ -71,21 +64,8 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-          DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "" # i.e. none
         run: |
           ./gradlew -Dgradle.publish.key="$GRADLE_PUBLISH_KEY" -Dgradle.publish.secret="$GRADLE_PUBLISH_SECRET" publishPlugins
-
-  submit-dependencies:
-    if: github.event_name == 'push'
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Submit dependencies
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
-        with:
-          dependency-graph: download-and-submit
 
   create-gh-release:
     if: startsWith(github.ref, 'refs/tags/') && !endsWith(github.ref, '-alpha')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: runtimeClasspath
-          DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "^(?!test-).*"
+          DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "^:(?!(buildSrc|test-)).*"
         run: ./gradlew build coveralls
       - name: Publish
         if: github.event_name == 'push' || github.event.inputs.publish_artifacts == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: ./gradlew build coveralls -DDEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS=runtimeClasspath
+        run: ./gradlew build coveralls -DDEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS=RuntimeClasspath
       - name: Publish
         if: github.event_name == 'push' || github.event.inputs.publish_artifacts == 'true'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,8 @@ jobs:
       - name: Build
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: runtimeClasspath
+          DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "^(?!test-).*"
         run: ./gradlew build coveralls
       - name: Publish
         if: github.event_name == 'push' || github.event.inputs.publish_artifacts == 'true'
@@ -58,6 +60,7 @@ jobs:
           ORG_GRADLE_PROJECT_SONA_USERNAME: ${{ secrets.SONA_USERNAME }}
           ORG_GRADLE_PROJECT_SONA_PASSWORD: ${{ secrets.SONA_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "" # i.e. none
         run: |
           ./gradlew cV
           ./gradlew publish closeAndReleaseStagingRepository
@@ -68,6 +71,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+          DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "" # i.e. none
         run: |
           ./gradlew -Dgradle.publish.key="$GRADLE_PUBLISH_KEY" -Dgradle.publish.secret="$GRADLE_PUBLISH_SECRET" publishPlugins
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: ./gradlew build coveralls -DDEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS=RuntimeClasspath
+        run: ./gradlew build coveralls
       - name: Publish
         if: github.event_name == 'push' || github.event.inputs.publish_artifacts == 'true'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: ./gradlew build coveralls -DDEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS=RuntimeClasspath
+        run: ./gradlew build coveralls -DDEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS=runtimeClasspath
       - name: Publish
         if: github.event_name == 'push' || github.event.inputs.publish_artifacts == 'true'
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,11 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
-          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
+        with:
+          gradle-home-cache-cleanup: true
 
       - name: Build
         run: ./gradlew test

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,8 +3,7 @@
 name: Dependabot
 on:
   pull_request:
-    branches:
-      - main
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,11 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
-          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
+        with:
+          gradle-home-cache-cleanup: true
       - name: Ensure build is green
         run: ./gradlew build
       - name: Release

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -30,6 +30,6 @@ jobs:
         env:
           DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: runtimeClasspath
           DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "^:(?!(buildSrc|test-)).*"
-        run: ./gradlew allDeps
+        run: ./gradlew allDeps --configuration runtimeClasspath
 
 

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -1,0 +1,35 @@
+name: Submit dependencies
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ "v*.*.*" ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1.1.0
+      - name: Set up JDK
+        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # v3.12.0
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
+        with:
+          dependency-graph: generate-and-submit
+          gradle-home-cache-cleanup: true
+      - name: Generate dependency report
+        env:
+          DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: runtimeClasspath
+          DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "^:(?!(buildSrc|test-)).*"
+        run: ./gradlew allDeps
+
+

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -31,7 +31,11 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
-          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
+        with:
+          gradle-home-cache-cleanup: true
       - name: Increment version
         if: contains(fromJson('["Major", "Minor", "Patch"]'), github.event.inputs.part)
         run: |

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -20,6 +20,7 @@
  * <p>Apply to all java modules, usually excluding the root project in multi-module sets.
  *
  * <p>Version: 1.8
+ *  - 1.9: Add `allDeps` task.
  *  - 1.8: Tweak test config to reduce build speed.
  *  - 1.7: Switch to setting Java version via toolchain
  *  - 1.6: Remove GitHub packages for snapshots
@@ -138,3 +139,5 @@ tasks.test {
     shouldRunAfter(static)
 }
 
+// See: https://solidsoft.wordpress.com/2014/11/13/gradle-tricks-display-dependencies-for-all-subprojects-in-multi-project-build/
+tasks.register<DependencyReportTask>("allDeps") {}


### PR DESCRIPTION
Issues with gradle-build-action dependency report generation means its cleaner to have it in its own workflow.