### PR TITLE
Investigate dependency submission plugin

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -30,7 +30,4 @@ jobs:
           dependency-graph: generate-and-submit
           gradle-home-cache-cleanup: true
       - name: Generate dependency report
-        env:
-          DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: runtimeClasspath
-          DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "^:(?!(buildSrc|test-)).*"
-        run: ./gradlew allDeps --configuration runtimeClasspath
+        run: ./gradlew allDeps

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -30,4 +30,7 @@ jobs:
           dependency-graph: generate-and-submit
           gradle-home-cache-cleanup: true
       - name: Generate dependency report
-        run: ./gradlew allDeps
+        run: ./gradlew dependencies allDeps
+      - name: Generate dependency report for buildSrc
+        run: (cd buildSrc && ../gradlew dependencies)
+


### PR DESCRIPTION
Temporarily removed filtering of configuration and projects to investigate [Gradle build action issue 61](https://github.com/gradle/github-dependency-graph-gradle-plugin/issues/61).

The `pl.allegro.tech.build.axion-release` is applied in the main build scripts, where as `org.javamodularity:moduleplugin` is an example of a plugin applied in `buildSrc`.  This will allow us to see where they are reported.