### PR TITLE
JPMS compatible schema output paths.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@
 
 version: 2
 registries:
+  maven-central:
+    type: maven-repository
+    url: https://repo.maven.apache.org/maven2/
   maven-snapshots:
     type: maven-repository
     url: https://s01.oss.sonatype.org/content/repositories/snapshots/
@@ -22,6 +25,7 @@ updates:
   - package-ecosystem: gradle
     directory: /
     registries:
+      - maven-central
       - maven-snapshots
       - creek-github-packages
     open-pull-requests-limit: 50

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,6 @@ subprojects {
         set("junitVersion", "5.10.1")            // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api
         set("junitPioneerVersion", "2.2.0")     // https://mvnrepository.com/artifact/org.junit-pioneer/junit-pioneer
         set("mockitoVersion", "5.8.0")          // https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
-        set("hamcrestVersion", "2.2")           // https://mvnrepository.com/artifact/org.hamcrest/hamcrest-core
     }
 
     val creekVersion : String by extra
@@ -66,7 +65,6 @@ subprojects {
     val junitVersion: String by extra
     val junitPioneerVersion: String by extra
     val mockitoVersion: String by extra
-    val hamcrestVersion : String by extra
 
     dependencies {
         testImplementation("org.creekservice:creek-test-util:$creekVersion")
@@ -76,10 +74,8 @@ subprojects {
         testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
         testImplementation("org.junit-pioneer:junit-pioneer:$junitPioneerVersion")
         testImplementation("org.mockito:mockito-junit-jupiter:$mockitoVersion")
-        testImplementation("org.hamcrest:hamcrest-core:$hamcrestVersion")
         testImplementation("com.google.guava:guava-testlib:$guavaVersion")
-        testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
-        testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion")
+        testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
     }
 }

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -20,6 +20,7 @@
  * <p>Apply to all java modules, usually excluding the root project in multi-module sets.
  *
  * <p>Versions:
+ *  - 1.11: Add explicit checkstyle tool version
  *  - 1.10: Add ability to exclude containerised tests
  *  - 1.9: Add `allDeps` task.
  *  - 1.8: Tweak test config to reduce build speed.
@@ -58,6 +59,7 @@ repositories {
 
 dependencies {
     spotbugsPlugins("com.h3xstream.findsecbugs:findsecbugs-plugin:1.12.0")
+    checkstyle("com.puppycrawl.tools:checkstyle:10.12.5")
 }
 
 configurations.all {

--- a/type/src/main/java/org/creekservice/api/base/type/schema/GeneratedSchemas.java
+++ b/type/src/main/java/org/creekservice/api/base/type/schema/GeneratedSchemas.java
@@ -20,6 +20,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.regex.Matcher;
 
 /**
  * Utility class for working with {@link
@@ -46,7 +47,8 @@ public final class GeneratedSchemas {
         final String className = idx == -1 ? fullName : fullName.substring(idx + 1);
         final String packageName = idx == -1 ? "" : fullName.substring(0, idx);
 
-        final String directory = packageName.replaceAll("\\.", File.separator);
+        final String directory =
+                packageName.replaceAll("\\.", Matcher.quoteReplacement(File.separator));
         return Paths.get(directory, className + extension);
     }
 

--- a/type/src/main/java/org/creekservice/api/base/type/schema/GeneratedSchemas.java
+++ b/type/src/main/java/org/creekservice/api/base/type/schema/GeneratedSchemas.java
@@ -17,6 +17,7 @@
 package org.creekservice.api.base.type.schema;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -29,7 +30,9 @@ public final class GeneratedSchemas {
     private GeneratedSchemas() {}
 
     /**
-     * The schema filename for a given type.
+     * The path to a schema for a given type.
+     *
+     * <p>Schemas are generated into the same package as the source type.
      *
      * @param type the type
      * @param extension the expected file extension, e.g. {@code ".yml"}.
@@ -37,14 +40,14 @@ public final class GeneratedSchemas {
      */
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "False positive")
     public static Path schemaFileName(final Class<?> type, final String extension) {
-        final String name =
-                type.getName()
-                        .replaceAll("([A-Z])", "_$1")
-                        .replaceFirst("_", "")
-                        .replaceAll("\\$_", "\\$")
-                        .toLowerCase();
+        final String fullName = type.getName();
+        final int idx = fullName.lastIndexOf(".");
 
-        return Paths.get(name + extension);
+        final String className = idx == -1 ? fullName : fullName.substring(idx + 1);
+        final String packageName = idx == -1 ? "" : fullName.substring(0, idx);
+
+        final String directory = packageName.replaceAll("\\.", File.separator);
+        return Paths.get(directory, className + extension);
     }
 
     /**

--- a/type/src/test/java/org/creekservice/api/base/type/schema/GeneratedSchemasTest.java
+++ b/type/src/test/java/org/creekservice/api/base/type/schema/GeneratedSchemasTest.java
@@ -29,7 +29,7 @@ class GeneratedSchemasTest {
         assertThat(
                 GeneratedSchemas.schemaFileName(
                         GeneratedSchemasTest.class, GeneratedSchemas.yamlExtension()),
-                is(Path.of("org.creekservice.api.base.type.schema.generated_schemas_test.yml")));
+                is(Path.of("org/creekservice/api/base/type/schema/GeneratedSchemasTest.yml")));
     }
 
     @Test
@@ -38,7 +38,7 @@ class GeneratedSchemasTest {
                 GeneratedSchemas.schemaFileName(Nested.class, GeneratedSchemas.yamlExtension()),
                 is(
                         Path.of(
-                                "org.creekservice.api.base.type.schema.generated_schemas_test$nested.yml")));
+                                "org/creekservice/api/base/type/schema/GeneratedSchemasTest$Nested.yml")));
     }
 
     @Test
@@ -51,7 +51,7 @@ class GeneratedSchemasTest {
                 GeneratedSchemas.schemaFileName(Model.class, GeneratedSchemas.yamlExtension()),
                 is(
                         Path.of(
-                                "org.creekservice.api.base.type.schema.generated_schemas_test$1_model.yml")));
+                                "org/creekservice/api/base/type/schema/GeneratedSchemasTest$1Model.yml")));
     }
 
     private static final class Nested {}


### PR DESCRIPTION
JPMS requires resources that are accessible from outside the module to be in _unique_ and _open_ packages.

To achieve this, we place the generated schema in the same package as the source type.

(Update some build conventions too)
