### PR TITLE
upgrade Java 11 to 17

### DIFF
--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -94,7 +94,7 @@ tasks.test {
 
 spotless {
     java {
-        googleJavaFormat("1.15.0").aosp().reflowLongStrings()
+        googleJavaFormat("1.25.2").aosp().reflowLongStrings()
         leadingTabsToSpaces()
         importOrder()
         removeUnusedImports()

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -43,7 +43,7 @@ group = "org.creekservice"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 


### PR DESCRIPTION
Upgrades Java version from 11 to 17.

## Files changed
- `buildSrc/src/main/kotlin/creek-common-convention.gradle.kts`: Updated `JavaLanguageVersion.of(11)` to `JavaLanguageVersion.of(17)`

Note: Workflow files already reference Java 17.