### PR TITLE
chore: update buildSrc plugin versions

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
     gradlePluginPortal()
 }
 
-val jvmTargetVer = JavaLanguageVersion.of(11)
+val jvmTargetVer = JavaLanguageVersion.of(17)
 
 java {
     toolchain.languageVersion.set(jvmTargetVer)
@@ -37,7 +37,7 @@ kotlin {
 
 
 dependencies {
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.2.6")                // https://plugins.gradle.org/plugin/com.github.spotbugs
+    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.4.8")                // https://plugins.gradle.org/plugin/com.github.spotbugs
     implementation("com.diffplug.spotless:spotless-plugin-gradle:7.2.1")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
     implementation("org.javamodularity:moduleplugin:2.0.0")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")                           // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin


### PR DESCRIPTION
Aligns buildSrc plugin versions with the rest of the Creek estate:
- spotbugs-gradle-plugin → 6.4.8
- plugin-publish-plugin → 2.1.1 (where applicable)
- buildSrc JVM target → Java 17 (where applicable)
- Kotlin DSL syntax fix (where applicable)