### PR TITLE
fix: don't fail CI if Codecov upload fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: '**/build/reports/jacoco/test/jacocoTestReport.xml'
-          fail_ci_if_error: true
+          fail_ci_if_error: false
       - name: Upload Reports
         if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
Dependabot PRs don't have access to the `CODECOV_TOKEN` secret, causing the Codecov upload step to fail with 'Token required because branch is protected'. Setting `fail_ci_if_error` to `false` prevents this from blocking builds.

This fix unblocks PR #444 and similar future dependabot PRs. Once this is merged, PR #444 can be rebased to pick up the fix.